### PR TITLE
Auto-format Bazel files using standard 'buildifier' tool

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,27 +2,27 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
     name = "grpc",
-    hdrs = [
-        "stout/grpc/call-type.h",
-        "stout/grpc/traits.h",
-        "stout/grpc/client.h",
-        "stout/grpc/handler.h",
-        "stout/grpc/cluster.h",
-        "stout/grpc/completion-pool.h",
-        "stout/grpc/server.h",
-        "stout/grpc/logging.h",
-    ],
     srcs = [
         "stout/grpc/server.cc",
     ],
-    deps = [
-        "@com_github_3rdparty_stout_borrowed_ptr//:borrowed_ptr",
-        "@com_github_3rdparty_stout_notification//:notification",
-        "@com_github_3rdparty_stout_eventuals//:eventuals",
-        "@com_google_absl//absl/base:base",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_github_google_glog//:glog",
-        "@com_github_grpc_grpc//:grpc++",
+    hdrs = [
+        "stout/grpc/call-type.h",
+        "stout/grpc/client.h",
+        "stout/grpc/cluster.h",
+        "stout/grpc/completion-pool.h",
+        "stout/grpc/handler.h",
+        "stout/grpc/logging.h",
+        "stout/grpc/server.h",
+        "stout/grpc/traits.h",
     ],
     visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_3rdparty_stout_borrowed_ptr//:borrowed_ptr",
+        "@com_github_3rdparty_stout_eventuals//:eventuals",
+        "@com_github_3rdparty_stout_notification//:notification",
+        "@com_github_google_glog//:glog",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/container:flat_hash_map",
+    ],
 )

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -3,30 +3,30 @@ load("@rules_cc//cc:defs.bzl", "cc_test")
 cc_test(
     name = "grpc",
     srcs = [
-        "test.h",
-        "build-and-start.cc",
-        "unimplemented.cc",
-        "cancelled-by-server.cc",
-        "cancelled-by-client.cc",
-        "unary.cc",
-        "streaming.cc",
-        "server-unavailable.cc",
-        "client-death-test.cc",
-        "server-death-test.cc",
-        "multiple-hosts.cc",
         "accept.cc",
-        "cluster.cc",
         "broadcast-cancel.cc",
+        "build-and-start.cc",
+        "cancelled-by-client.cc",
+        "cancelled-by-server.cc",
+        "client-death-test.cc",
+        "cluster.cc",
         "deadline.cc",
-    ],
-    deps = [
-        "//:grpc",
-        "@com_github_grpc_grpc//examples/protos:helloworld_cc_grpc",
-        "@com_github_grpc_grpc//examples/protos:keyvaluestore",
-        "@com_github_google_googletest//:gtest_main",
+        "multiple-hosts.cc",
+        "server-death-test.cc",
+        "server-unavailable.cc",
+        "streaming.cc",
+        "test.h",
+        "unary.cc",
+        "unimplemented.cc",
     ],
     # NOTE: need to add 'linkstatic = True' in order to get this to
     # link until https://github.com/grpc/grpc/issues/13856 gets
     # resolved.
     linkstatic = True,
+    deps = [
+        "//:grpc",
+        "@com_github_google_googletest//:gtest_main",
+        "@com_github_grpc_grpc//examples/protos:helloworld_cc_grpc",
+        "@com_github_grpc_grpc//examples/protos:keyvaluestore",
+    ],
 )


### PR DESCRIPTION
Before this PR, our `BUILD.bazel` files were not auto-formatted.

This PR uses `buildifier` (analogous to `prettier`, `gofmt`, etc.) to auto-format the `BUILD.bazel` files in this repo. There are no functional changes, only formatting.