### PR TITLE
Refactor streaming test

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,4 @@
 # Specific Bazel build/test options.
 
 build --cxxopt='-std=c++17'
+test --cxxopt='-fstandalone-debug' -c dbg --strip='never'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.vscode/
+bazel-bin
+bazel-out
+bazel-stout-grpc
+bazel-testlogs

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_cc//cc:defs.bzl", "cc_test")
 
 cc_test(
     name = "grpc",
+    timeout = "short",
     srcs = [
         "accept.cc",
         "broadcast-cancel.cc",
@@ -14,10 +15,28 @@ cc_test(
         "multiple-hosts.cc",
         "server-death-test.cc",
         "server-unavailable.cc",
-        "streaming.cc",
         "test.h",
         "unary.cc",
         "unimplemented.cc",
+    ],
+    # NOTE: need to add 'linkstatic = True' in order to get this to
+    # link until https://github.com/grpc/grpc/issues/13856 gets
+    # resolved.
+    linkstatic = True,
+    deps = [
+        "//:grpc",
+        "@com_github_google_googletest//:gtest_main",
+        "@com_github_grpc_grpc//examples/protos:helloworld_cc_grpc",
+        "@com_github_grpc_grpc//examples/protos:keyvaluestore",
+    ],
+)
+
+cc_test(
+    name = "streaming",
+    timeout = "short",
+    srcs = [
+        "streaming.cc",
+        "test.h",
     ],
     # NOTE: need to add 'linkstatic = True' in order to get this to
     # link until https://github.com/grpc/grpc/issues/13856 gets


### PR DESCRIPTION
Before this PR, `test/streaming.cc` was a single large monolithic test that would not allow us to test multiple different client behaviors easily. 

This PR leaves the test functionally identical, but factors out the code that produces the client behavior (which the next commit will introduce various versions of) from the framework of the test (which will not change). It also splits `streaming.cc` into a separate `cc_test` target, so that it can be built and tested in isolation more easily, for faster write/test-iteration.

As a bonus, adds a `.gitignore` file to this repo, and sets some flags helpful for debugging in the `.bazelrc`.