### PR TITLE
Fix a family of concurrency bugs

### DIFF
--- a/test/streaming.cc
+++ b/test/streaming.cc
@@ -20,6 +20,26 @@ using stout::eventuals::grpc::Server;
 using stout::eventuals::grpc::ServerBuilder;
 using stout::eventuals::grpc::Stream;
 
+// We can vary the usage of the streaming API on three dimensions, each of which
+// leads to different concurrency situations in `client.h`:
+// 1. Do we use WriteLast() or WritesDone() to close the gRPC stream?
+// 2. Do we close the gRPC stream before or after receiving a reply?
+// 3. Do we send one, or multiple requests before closing the stream?
+//
+// This leads to 2*2*2=8 different possible test cases. Of those, one
+// combination is nonsensical: if we...
+//   ... use WriteLast(), which sends a request
+//   ... after receiving a reply to a request
+//   ... we MUST therefore be sending more than one request before closing.
+//
+// All other 7 test cases are important; we've had unique bugs in each of them!
+//
+// Test naming is structured as follows:
+//   Streaming
+//     _[WriteLast|WritesDone]
+//     _[AfterReply|BeforeReply]
+//     _[OneRequest|TwoRequests]
+
 template <class T>
 void test_client_behavior(T&& handler) {
   ServerBuilder builder;
@@ -90,7 +110,7 @@ void test_client_behavior(T&& handler) {
   EXPECT_FALSE(cancelled.get());
 }
 
-TEST_F(StoutGrpcTest, Streaming_FinishAfterReply) {
+TEST_F(StoutGrpcTest, Streaming_WriteLast_AfterReply_TwoRequests) {
   test_client_behavior(Client::Handler()
                            .ready([](auto& call) {
                              keyvaluestore::Request request;
@@ -103,6 +123,179 @@ TEST_F(StoutGrpcTest, Streaming_FinishAfterReply) {
                                        keyvaluestore::Request request;
                                        request.set_key("2");
                                        call.WriteLast(request);
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("2", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("10", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("11", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("12", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_FALSE(response);
+                                     })));
+}
+
+TEST_F(StoutGrpcTest, Streaming_WriteLast_BeforeReply_OneRequest) {
+  test_client_behavior(Client::Handler()
+                           .ready([](auto& call) {
+                             keyvaluestore::Request request;
+                             request.set_key("1");
+                             call.WriteLast(request);
+                           })
+                           .body(Sequence()
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("1", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("10", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("11", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("12", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_FALSE(response);
+                                     })));
+}
+
+TEST_F(StoutGrpcTest, Streaming_WriteLast_BeforeReply_TwoRequests) {
+  test_client_behavior(Client::Handler()
+                           .ready([](auto& call) {
+                             keyvaluestore::Request request1;
+                             request1.set_key("1");
+                             call.Write(request1);
+                             keyvaluestore::Request request2;
+                             request2.set_key("2");
+                             call.WriteLast(request2);
+                           })
+                           .body(Sequence()
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("1", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("2", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("10", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("11", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("12", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_FALSE(response);
+                                     })));
+}
+
+TEST_F(StoutGrpcTest, Streaming_WritesDone_AfterReply_OneRequest) {
+  test_client_behavior(Client::Handler()
+                           .ready([](auto& call) {
+                             keyvaluestore::Request request;
+                             request.set_key("1");
+                             call.Write(request);
+                           })
+                           .body(Sequence()
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("1", response->value());
+                                       call.WritesDone();
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("10", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("11", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("12", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_FALSE(response);
+                                     })));
+}
+
+
+TEST_F(StoutGrpcTest, Streaming_WritesDone_AfterReply_TwoRequests) {
+  test_client_behavior(Client::Handler()
+                           .ready([](auto& call) {
+                             keyvaluestore::Request request;
+                             request.set_key("1");
+                             call.Write(request);
+                           })
+                           .body(Sequence()
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("1", response->value());
+                                       keyvaluestore::Request request;
+                                       request.set_key("2");
+                                       call.Write(request);
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("2", response->value());
+                                       call.WritesDone();
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("10", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("11", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("12", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_FALSE(response);
+                                     })));
+}
+
+TEST_F(StoutGrpcTest, Streaming_WritesDone_BeforeReply_OneRequest) {
+  test_client_behavior(Client::Handler()
+                           .ready([](auto& call) {
+                             keyvaluestore::Request request1;
+                             request1.set_key("1");
+                             call.Write(request1);
+                             call.WritesDone();
+                           })
+                           .body(Sequence()
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("1", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("10", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("11", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("12", response->value());
+                                     })
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_FALSE(response);
+                                     })));
+}
+
+TEST_F(StoutGrpcTest, Streaming_WritesDone_BeforeReply_TwoRequests) {
+  test_client_behavior(Client::Handler()
+                           .ready([](auto& call) {
+                             keyvaluestore::Request request1;
+                             request1.set_key("1");
+                             call.Write(request1);
+                             keyvaluestore::Request request2;
+                             request2.set_key("2");
+                             call.Write(request2);
+                             call.WritesDone();
+                           })
+                           .body(Sequence()
+                                     .Once([](auto& call, auto&& response) {
+                                       EXPECT_EQ("1", response->value());
                                      })
                                      .Once([](auto& call, auto&& response) {
                                        EXPECT_EQ("2", response->value());


### PR DESCRIPTION
Before this PR, the only way we tested the streaming API was...
1. By closing streams with `WriteLast()`, not `WritesDone()`.
2. By closing streams after replies have arrived, not before.
3. By sending two requests, no fewer.

Varying each of these dimensions exposed (combinations of) concurrency bugs that would result in the stream failing to be closed properly.

For example: if two requests were enqueued and `WritesDone()` was called before any replies had arrived, then code in `client.h::WritesDone()` would (correctly) avoid calling `stream_->WritesDone()`, since `write_callback_` would still have another `stream_->Write()` to do. However, the `write_callback_` would fail to perform the omitted `stream_->WriteLast()` or `stream_->WritesDone()` later, skipping straight to `stream_->Finish()`, which would cause the whole application to hang.

This PR reworks our write callback, so that we always correctly transition between the Not-Writing/Writing/Writes-Done/Finished states that this client can be in.

TESTED: a bunch of new unit tests in `streaming.cc`.

I'm requesting review primarily from @while-false, but I'm also adding @benh for an optional post-vacation review, since this stuff is persnickety and today was the first time I looked at any of this.