### PR TITLE
Fix mutex usage bugs, and prevent recurrence

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
 # Specific Bazel build/test options.
 
-build --cxxopt='-std=c++17' --cxxopt='-Werror=thread-safety-analysis'
+build --cxxopt='-std=c++17' 
+build --cxxopt='-Werror=thread-safety-analysis' --cxxopt='-Werror=thread-safety-reference'
 test --cxxopt='-fstandalone-debug' -c dbg --strip='never'

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
 # Specific Bazel build/test options.
 
-build --cxxopt='-std=c++17'
+build --cxxopt='-std=c++17' --cxxopt='-Werror=thread-safety-analysis'
 test --cxxopt='-fstandalone-debug' -c dbg --strip='never'

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,5 +24,6 @@ cc_library(
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/base",
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/synchronization",
     ],
 )

--- a/stout/grpc/client.h
+++ b/stout/grpc/client.h
@@ -2,6 +2,7 @@
 
 #include <cassert>
 
+#include "absl/synchronization/mutex.h"
 #include "grpcpp/client_context.h"
 #include "grpcpp/completion_queue.h"
 #include "grpcpp/create_channel.h"
@@ -139,7 +140,7 @@ struct _Call {
 
             write_callback_ = [this](bool ok) mutable {
               if (ok) {
-                mutex_.lock();
+                mutex_.Lock();
 
                 // Might be getting here after doing a 'WritesDone()'
                 // and now just need to do 'Finish()'.
@@ -176,7 +177,7 @@ struct _Call {
                   next_action = NextAction::WRITES_DONE;
                 }
 
-                mutex_.unlock();
+                mutex_.Unlock();
 
                 if (next_action == NextAction::WRITE) {
                   stream_->Write(*request, *options, &write_callback_);
@@ -187,10 +188,10 @@ struct _Call {
                   stream_->WritesDone(&writes_done_callback_);
                 }
               } else {
-                mutex_.lock();
+                mutex_.Lock();
                 write_datas_.clear();
                 write_callback_ = Callback<bool>();
-                mutex_.unlock();
+                mutex_.Unlock();
 
                 // NOTE: the invariant here is that we won't exeute
                 // 'Finish()' more than once because it's callback is
@@ -276,7 +277,7 @@ struct _Call {
     void WritesDone() {
       bool write = false;
 
-      mutex_.lock();
+      mutex_.Lock();
       assert(!finish_); // Only call one of WriteLast() or WritesDone() once.
       finish_ = true;
       if (write_callback_ && write_datas_.empty()) {
@@ -285,7 +286,7 @@ struct _Call {
         // We'll do a `WritesDone()` ourselves.
         write = true;
       }
-      mutex_.unlock();
+      mutex_.Unlock();
 
       if (write) {
         stream_->WritesDone(&writes_done_callback_);
@@ -303,7 +304,7 @@ struct _Call {
         bool last) {
       bool write = false;
 
-      mutex_.lock();
+      mutex_.Lock();
 
       if (last) {
         assert(!finish_); // Only call one of WriteLast() or WritesDone() once.
@@ -325,7 +326,7 @@ struct _Call {
           write = true;
         }
 
-        mutex_.unlock();
+        mutex_.Unlock();
 
         if (write) {
           if (!last) {
@@ -336,7 +337,7 @@ struct _Call {
         }
       }
 
-      mutex_.unlock();
+      mutex_.Unlock();
     }
 
     K_ k_;
@@ -373,7 +374,7 @@ struct _Call {
     };
 
     // TODO(benh): render this lock-free.
-    std::mutex mutex_;
+    absl::Mutex mutex_;
     std::list<WriteData> write_datas_;
 
     bool finish_ = false;


### PR DESCRIPTION
Before this PR, the following code would compile, and would in fact run without obvious errors:
```c++
std::mutex m;
m.lock();
m.unlock();
m.unlock(); // UNDEFINED BEHAVIOR! RACE CONDITIONS! DRAGONS!
```

This type of error was occurring at `client.h` line `340`, where we MAY do a double unlock on a mutex that was previously unlocked at line `329`. It also happened at `server.h` line `671`.

We happened to spot this issue by code inspection this time, but we should avoid making similar mistakes in the future.

While `std::mutex` can't help us much, Google's `absl::Mutex` will help us catch this class of error automatically: it'll produce a compile-time warning for many types of invalid-mutex-use, including double-lock, double-unlock, potential deadlocks, ...; this PR also upgrades those warnings to compile-time errors.

This PR...
1. Replaces std::mutex with absl::Mutex.
2. Makes our builds fail if we violate absl::Mutex's thread safety checks.

Now look at the beautiful errors we get:
```
./stout/grpc/client.h:340:7: error: mutex 'mutex_' is not held on every path through here [-Werror,-Wthread-safety-analysis]
      mutex_.Unlock();
      ^
```

And:
```
./stout/grpc/server.h:671:7: error: mutex 'mutex_' is not held on every path through here [-Werror,-Wthread-safety-analysis]
      mutex_.Unlock();
      ^
```

With the build now broken, this PR continues by fixing the two incorrect (double-release) issues.

All we strictly needed to do was to avoid the double-release in `client.h::WriteMaybeLast()` and `server.h::WriteMaybeFinish()`. However, we're taking this opportunity to improve how we use mutexes, by introducing `absl::MutexLock` and `absl::ReleasableMutexLock`, which ensure that we can never forget to release a Mutex. See [here](https://abseil.io/docs/cpp/guides/synchronization#the-mutexlock-wrapper) for more info.

For bonus points we also demonstrate the use of [Thread Annotations](https://abseil.io/docs/cpp/guides/synchronization#thread-annotations) which further improve our ability to find any future mistakes.

REVIEWING NOTES:
* Requesting review primarily from @while-false , but CCing @benh for future reference.
* Unfortunately, changed indentation as a result of introducing scopes for the `MutexLock`s is causing the diff to look much bigger than it is. My apologies...

TESTED: made compiler reject the buggy code, then fixed the code. Unit tests continue to pass.