### PR TITLE
Added code_format_check.yml

### DIFF
--- a/.github/workflows/check_format_code.yml
+++ b/.github/workflows/check_format_code.yml
@@ -1,0 +1,16 @@
+name: C/C++ Style Check
+
+on: [push, pull_request]
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run bootstrap
+      run: cd tools/ && ./bootstrap
+    - name: Run clang-format style check for C/C++ programs.
+      uses: jidicula/clang-format-action@v4.0.0
+      with:
+        clang-format-version: '12'
+        check-path: '.'


### PR DESCRIPTION
This .yml file helps to verify that a repo's formatting matches our
specifications (`.clang-format` file in the root directory), but doesn't
automatically fix any issues.

For now I need to figure out how to make this action automatically
check if every line of the code exceeds 80 characters.